### PR TITLE
Fix for bug in cdfpsi, issue #15

### DIFF
--- a/src/cdfio.F90
+++ b/src/cdfio.F90
@@ -1422,7 +1422,7 @@ CONTAINS
 
   END FUNCTION FindVarName
 
-  FUNCTION  getvar (cdfile,cdvar,klev,kpi,kpj,kimin,kjmin, ktime, ldiom)
+  FUNCTION  getvar (cdfile,cdvar,klev,kpi,kpj,kimin,kjmin, ktime, ldiom, ld_zeromask)
     !!---------------------------------------------------------------------
     !!                  ***  FUNCTION  getvar  ***
     !!
@@ -1443,6 +1443,7 @@ CONTAINS
     INTEGER(KIND=4), OPTIONAL, INTENT(in) :: kimin, kjmin ! Optional variable. If missing 1 is assumed
     INTEGER(KIND=4), OPTIONAL, INTENT(in) :: ktime        ! Optional variable. If missing 1 is assumed
     LOGICAL,         OPTIONAL, INTENT(in) :: ldiom        ! Optional variable. If missing false is assumed
+    LOGICAL,         OPTIONAL, INTENT(in) :: ld_zeromask   ! Optional variable. Reset field to zero at missing value points. If missing false is assumed
     REAL(KIND=4), DIMENSION(kpi,kpj) :: getvar            ! 2D REAL 4 holding variable field at klev
 
     INTEGER(KIND=4), DIMENSION(4)               :: istart, icount, inldim
@@ -1454,7 +1455,7 @@ CONTAINS
     REAL(KIND=4)                                :: spval  !: missing value
     REAL(KIND=4) , DIMENSION (:,:), ALLOCATABLE :: zend, zstart
     CHARACTER(LEN=256)                          :: clvar
-    LOGICAL                                     :: lliom=.false., llperio=.false.
+    LOGICAL                                     :: lliom=.false., llperio=.false., ll_zeromask=.false.
     LOGICAL                                     :: llog=.FALSE. , lsf=.FALSE. , lao=.FALSE.
     !!
     INTEGER(KIND=4)                :: ityp
@@ -1497,6 +1498,12 @@ CONTAINS
        lliom=ldiom
     ELSE
        lliom=.false.
+    ENDIF
+
+    IF (PRESENT(ld_zeromask) ) THEN
+       ll_zeromask=ld_zeromask
+    ELSE
+       ll_zeromask=.false.
     ENDIF
 
     ! Must reset the flags to false for every call to getvar
@@ -1603,7 +1610,8 @@ CONTAINS
     IF (lsf )  WHERE (getvar /= spval )  getvar=getvar*sf
     IF (lao )  WHERE (getvar /= spval )  getvar=getvar + ao
     IF (llog)  WHERE (getvar /= spval )  getvar=10**getvar
-
+    IF (ll_zeromask) WHERE (getvar == spval ) getvar=0.0
+    
     istatus=NF90_CLOSE(incid)
 
   END FUNCTION getvar

--- a/src/cdfpsi.f90
+++ b/src/cdfpsi.f90
@@ -243,6 +243,7 @@ PROGRAM cdfpsi
 
   CALL CreateOutput
 
+  PRINT *, 'Getting ',TRIM(cn_ve1v), TRIM(cn_ve2u)
   e1v(:,:)   = getvar(cn_fhgr, cn_ve1v, 1, npiglo, npjglo)
   e2u(:,:)   = getvar(cn_fhgr, cn_ve2u, 1, npiglo, npjglo)
   IF ( lmask) THEN
@@ -270,7 +271,7 @@ PROGRAM cdfpsi
 
      DO jk = 1,npk
         IF ( ll_v ) THEN
-           zv(:,:) = getvar(cf_vfil, cn_vomecrty, jk, npiglo, npjglo, ktime=jt )
+           zv(:,:) = getvar(cf_vfil, cn_vomecrty, jk, npiglo, npjglo, ktime=jt, ld_zeromask=.true. )
            IF ( lfull ) THEN ; e3v(:,:) = e31d(jk)
            ELSE              ; e3v(:,:) = getvar(cn_fe3v, cn_ve3v, jk, npiglo, npjglo, ktime=it, ldiom=.NOT.lg_vvl)
            ENDIF
@@ -289,7 +290,8 @@ PROGRAM cdfpsi
         ENDIF
 
         IF ( ll_u) THEN
-           zu(:,:) = getvar(cf_ufil, cn_vozocrtx, jk, npiglo, npjglo, ktime=jt )
+           zu(:,:) = getvar(cf_ufil, cn_vozocrtx, jk, npiglo, npjglo, ktime=jt, ld_zeromask=.true. )
+           PRINT *, 'Getting ',TRIM(cn_ve3u)
            IF ( lfull ) THEN ; e3u(:,:) = e31d(jk)
            ELSE              ; e3u(:,:) = getvar(cn_fe3u, cn_ve3u, jk, npiglo, npjglo, ktime=it, ldiom=.NOT.lg_vvl)
            ENDIF


### PR DESCRIPTION
I have fixed this by reinstating the functionality in getvar to zero the field over land, depending on the optional input parameter ld_zeroland. Then I call getvar with this option from cdfpsi.